### PR TITLE
Add id-token: write permission to Claude agent workflow

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -27,6 +27,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   # ─────────────────────────────────────────────────────────


### PR DESCRIPTION
The Claude Code Action needs OIDC token permission to authenticate with GitHub API for creating branches and PRs.