### PR TITLE
Add /ping health check endpoint

### DIFF
--- a/backend/adk_app/api/routes/health.py
+++ b/backend/adk_app/api/routes/health.py
@@ -1,6 +1,7 @@
 """
 Health check route.
 """
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends
 
 from adk_app.services.supabase_service import get_supabase_admin_client
@@ -11,6 +12,15 @@ from adk_app.api.middleware.auth import (
 )
 
 router = APIRouter(tags=["Health"])
+
+
+@router.get("/ping")
+def ping() -> dict:
+    """Ping endpoint with status and timestamp."""
+    return {
+        "status": 200,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
 
 
 @router.get("/healthz")


### PR DESCRIPTION
Adds a new `/ping` endpoint that returns status 200 and an ISO 8601 timestamp in JSON format.

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)