### PR TITLE
Add /version endpoint to health routes

### DIFF
--- a/backend/adk_app/api/routes/health.py
+++ b/backend/adk_app/api/routes/health.py
@@ -23,6 +23,15 @@ def ping() -> dict:
     }
 
 
+@router.get("/version")
+def version() -> dict:
+    """Version endpoint returning app version and environment."""
+    return {
+        "version": "1.0.0",
+        "environment": "development"
+    }
+
+
 @router.get("/healthz")
 def health() -> dict:
     """Health check endpoint."""


### PR DESCRIPTION
Added a new GET /version endpoint that returns:
- version: "1.0.0"
- environment: "development"

The endpoint follows the same pattern as other health check endpoints.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)