### PR TITLE
Add timezone and timestamp to /version endpoint

### DIFF
--- a/backend/adk_app/api/routes/health.py
+++ b/backend/adk_app/api/routes/health.py
@@ -25,10 +25,12 @@ def ping() -> dict:
 
 @router.get("/version")
 def version() -> dict:
-    """Version endpoint returning app version and environment."""
+    """Version endpoint returning app version, environment, and timezone information."""
     return {
         "version": "1.0.0",
-        "environment": "development"
+        "environment": "development",
+        "timezone": "UTC",
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }
 
 


### PR DESCRIPTION
Added timezone and timestamp information to the /version endpoint.

The endpoint now returns:
- version: "1.0.0"
- environment: "development"
- timezone: "UTC"
- timestamp: current UTC time in ISO format

This makes it easy to track when the version was last checked and what timezone the system uses.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)