### PR TITLE
Increase agent max turns and allow bash for testing

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -68,5 +68,8 @@ jobs:
           branch_prefix: "claude/"
 
           # Additional Claude Code CLI arguments
+          # --max-turns 50: TDD workflow needs more steps (read→test→code→verify)
+          # --allowedTools: Allow bash commands needed for testing and verification
           claude_args: |
-            --max-turns 25
+            --max-turns 50
+            --allowedTools "Edit,Write,Read,Bash(pip:*),Bash(python:*),Bash(cd:*),Bash(npm:*),Bash(git:*),Glob,Grep"


### PR DESCRIPTION
- Increase --max-turns from 25 to 50 (TDD workflow needs more steps: read code, read tests, write tests, write code, run tests, verify)
- Add --allowedTools to permit pip install, python/pytest execution, npm build, and git commands needed for the testing workflow