### PR TITLE
fix: change /version endpoint timezone from UTC to IST

### DIFF
--- a/backend/adk_app/api/routes/health.py
+++ b/backend/adk_app/api/routes/health.py
@@ -1,7 +1,7 @@
 """
 Health check route.
 """
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Depends
 
 from adk_app.services.supabase_service import get_supabase_admin_client
@@ -26,16 +26,18 @@ def ping() -> dict:
 @router.get("/version")
 def version() -> dict:
     """Version endpoint returning app version, environment, and timezone information."""
-    # Format timestamp as human-readable: "February 18, 2026 at 7:29 AM UTC"
-    now = datetime.now(timezone.utc)
+    # IST is UTC+5:30
+    ist = timezone(timedelta(hours=5, minutes=30))
+    now = datetime.now(ist)
+    # Format as human-readable: "February 18, 2026 at 7:29 AM IST"
     # Use %I for 12-hour format, strip leading zero if present for cross-platform compatibility
-    hour_12 = now.strftime("%I").lstrip("0")
-    human_timestamp = f"{now.strftime('%B %d, %Y')} at {hour_12}:{now.strftime('%M %p')} UTC"
+    hour_12 = now.strftime("%I").lstrip("0") or "12"
+    human_timestamp = f"{now.strftime('%B %d, %Y')} at {hour_12}:{now.strftime('%M %p')} IST"
 
     return {
         "version": "1.0.0",
         "environment": "development",
-        "timezone": "UTC",
+        "timezone": "IST",
         "timestamp": human_timestamp
     }
 

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -28,7 +28,7 @@ class TestVersion:
         assert "timestamp" in data
 
     def test_version_timestamp_is_human_readable(self, http_client):
-        """Version endpoint timestamp is in human-readable format."""
+        """Version endpoint timestamp is in human-readable IST format."""
         response = http_client.get("/version")
         assert response.status_code == 200
 
@@ -38,10 +38,20 @@ class TestVersion:
         # Should NOT be ISO format (contains 'T' and '+')
         assert 'T' not in timestamp, f"Timestamp should not be ISO format: {timestamp}"
 
-        # Should be human-readable format like "February 18, 2026 at 7:29 AM UTC"
-        # Pattern: Month DD, YYYY at HH:MM AM/PM UTC
-        pattern = r'^[A-Z][a-z]+ \d{1,2}, \d{4} at \d{1,2}:\d{2} (AM|PM) UTC$'
-        assert re.match(pattern, timestamp), f"Timestamp should match human-readable format: {timestamp}"
+        # Updated: /version now returns IST timezone (changed from UTC in issue #24)
+        # Should be human-readable format like "February 18, 2026 at 7:29 AM IST"
+        # Pattern: Month DD, YYYY at HH:MM AM/PM IST
+        pattern = r'^[A-Z][a-z]+ \d{1,2}, \d{4} at \d{1,2}:\d{2} (AM|PM) IST$'
+        assert re.match(pattern, timestamp), f"Timestamp should match human-readable IST format: {timestamp}"
+
+    def test_version_timezone_is_ist(self, http_client):
+        """Version endpoint timezone field returns IST."""
+        response = http_client.get("/version")
+        assert response.status_code == 200
+
+        data = response.json()
+        # Updated: timezone is now IST (changed from UTC in issue #24)
+        assert data["timezone"] == "IST", f"Expected timezone 'IST', got '{data['timezone']}'"
 
     def test_version_has_correct_structure(self, http_client):
         """Version endpoint returns all expected fields with correct types."""


### PR DESCRIPTION
Updates the `/version` endpoint to use Indian Standard Time (IST, UTC+5:30) instead of UTC, and keeps the timestamp in human-readable format.

Closes #24

Generated with [Claude Code](https://claude.ai/code)